### PR TITLE
fix: unauthorized when loading calendar

### DIFF
--- a/src/page/calendar.tsx
+++ b/src/page/calendar.tsx
@@ -5,7 +5,7 @@ import dayjs, { Dayjs } from "dayjs";
 import { firstDayOfMonth, lastDayOfMonth } from "../lib/utils";
 import { invoke } from "@tauri-apps/api";
 import useMessage from "antd/es/message/useMessage";
-import { CalendarEvent, Colors } from "../lib/model";
+import { CalendarEvent, Colors, Course } from "../lib/model";
 
 export default function CalendarPage() {
     const [currentDate, setCurrentDate] = useState<Dayjs>(dayjs());
@@ -34,14 +34,10 @@ export default function CalendarPage() {
     }
 
     const init = async () => {
-        let colors = await getColors() as Colors;
-        let contextCodes = [];
-        for (let courseCode in colors.custom_colors) {
-            if (courseCode.startsWith("user")) {
-                continue;
-            }
-            contextCodes.push(courseCode);
-        }
+        const colors = await getColors() as Colors;
+        const courses = await invoke("list_courses") as Course[];
+        const courses_id = Array.from(courses, (course) => `course_${course.id}`);
+        const contextCodes = courses_id.filter((course_id) => Object.keys(colors.custom_colors).includes(course_id));
         setColors(colors);
         setContextCodes(contextCodes);
         getHints(contextCodes);


### PR DESCRIPTION
进入“日历”页面后，无法加载事件，提示未认证

![image](https://github.com/Okabe-Rintarou-0/SJTU-Canvas-Helper/assets/51732678/3ed2faea-cf06-4e55-a866-0f51e98fbb23)

检查后发现是在请求日历事件时，contextCodes参数传入了多余的课程，但这些课程用户是没有权限访问的

目前获取contextCodes的方法是从color里获取，但是这个接口可能会返回一些额外的课程。例如我调用color会返回23项，但我账号上只有18门可用课程

![image](https://github.com/Okabe-Rintarou-0/SJTU-Canvas-Helper/assets/51732678/b3dfcebd-eaf0-4566-aa0f-4e517b62688e)
![image](https://github.com/Okabe-Rintarou-0/SJTU-Canvas-Helper/assets/51732678/2844a6af-8627-4f93-b6ec-1865438bcd19)

不知道为什么canvas会出现这种情况，有可能是部分课程被删除/隐藏了。

修复方法是拿到课程列表，检查一下colors里面的编号是不是在课程列表里。