### PR TITLE
fix assignments page

### DIFF
--- a/src-tauri/src/model/mod.rs
+++ b/src-tauri/src/model/mod.rs
@@ -161,6 +161,7 @@ pub struct Assignment {
     #[serde(default)]
     pub needs_grading_count: Option<i32>,
     pub html_url: String,
+    pub submission_types: Vec<String>,
     #[serde(default)]
     pub allowed_extensions: Vec<String>,
     pub has_submitted_submissions: bool,

--- a/src/lib/model.ts
+++ b/src/lib/model.ts
@@ -95,6 +95,7 @@ export interface Assignment {
     course_id: number;
     name: string;
     html_url: string;
+    submission_types: string[];
     allowed_extensions?: string[];
     published: boolean;
     has_submitted_submissions: boolean;

--- a/src/page/assignments.tsx
+++ b/src/page/assignments.tsx
@@ -99,7 +99,8 @@ export default function AssignmentsPage() {
             } else {
                 tags.push(<Tag color="blue">进行中</Tag>);
             }
-            if (!submission) {
+            if (!submission ||
+                assignment.submission_types.includes("none") || assignment.submission_types.includes("not_graded")) {
                 // no need to submit
                 tags.push(<Tag>无需提交</Tag>);
             }

--- a/src/page/assignments.tsx
+++ b/src/page/assignments.tsx
@@ -49,6 +49,8 @@ export default function AssignmentsPage() {
     const initCourses = async () => {
         try {
             let courses = await invoke("list_courses") as Course[];
+            // sort by term id, latest first
+            courses.sort((a, b) => b.term.id - a.term.id);
             setCourses(courses);
         } catch (e) {
             messageApi.error(e as string);

--- a/src/page/assignments.tsx
+++ b/src/page/assignments.tsx
@@ -102,7 +102,7 @@ export default function AssignmentsPage() {
                 // no need to submit
                 tags.push(<Tag>无需提交</Tag>);
             }
-            else if (submission.workflow_state === "submitted") {
+            else if (submission.submitted_at) {
                 tags.push(submission.late ? <Tag color="red">迟交</Tag> : <Tag color="green">已提交</Tag>);
             }
             else {

--- a/src/page/assignments.tsx
+++ b/src/page/assignments.tsx
@@ -93,7 +93,8 @@ export default function AssignmentsPage() {
         render: (submission: Submission, assignment: Assignment) => {
             let tags = [];
             let dued = dayjs(assignment.due_at).isBefore(dayjs());
-            if (dued) {
+            let locked = dayjs(assignment.lock_at).isBefore(dayjs());
+            if (dued || locked) {
                 tags.push(<Tag color="orange">已截止</Tag>);
             } else {
                 tags.push(<Tag color="blue">进行中</Tag>);


### PR DESCRIPTION
有以下修改
1. 处理了已评分的作业会被错误标记为“未提交”的问题
2. 有部分作业只设置了关闭时间，没有设置截止时间，导致被错误的标注为“进行中”，即使其已经无法访问。
3. 修改了“无需提交”的条件判断，submission_types为none或not_graded的作业，在网页上不会显示提交按钮
4. 按照学期对课程进行排序，最近学期的课程在最前面


![image](https://github.com/Okabe-Rintarou-0/SJTU-Canvas-Helper/assets/51732678/851025a0-c2fd-486a-a4b1-142d026aa678)

如果一个作业已被评分，那么其workflow_state会变成graded
![image](https://github.com/Okabe-Rintarou-0/SJTU-Canvas-Helper/assets/51732678/e7d54614-52a6-4cd6-9112-3818985a2464)

只通过workflow_state没办法判断作业是否提交：即使一个作业未提交，其依然可能被打分。用`submission.submitted_at`判断应该更准确。

有部分作业只设置了关闭时间，没有设置截止时间，在关闭时间后作业会锁定，也应该记作“截止”。（虽然“关闭”和“截止”不完全一样，但是对于用户来说感觉没必要区分）

![image](https://github.com/Okabe-Rintarou-0/SJTU-Canvas-Helper/assets/51732678/7d11e187-9488-40a9-9796-d71ac3fe503f)


`submission_types`为none或not_graded的作业也是无需提交的，在网页上不会显示提交按钮。有一个奇怪的点，api文档里说`submission_types`不包含`not_graded`，但我确实有一门是这样的。

