### PR TITLE
feat: 更接近文件系统的文件视图

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "tauri": "tauri"
   },
   "dependencies": {
+    "@ant-design/icons": "^4.8.3",
     "@cyntler/react-doc-viewer": "^1.14.1",
     "@tauri-apps/api": "^1",
     "@tauri-apps/plugin-updater": "^2.0.0-beta.2",

--- a/src-tauri/src/client/mod.rs
+++ b/src-tauri/src/client/mod.rs
@@ -227,9 +227,27 @@ impl Client {
         self.list_items(&url, token).await
     }
 
+    // TODO: 将接口改为list_course_folders
     pub async fn list_folders(&self, course_id: i32, token: &str) -> Result<Vec<Folder>> {
         let url = format!("{}/api/v1/courses/{}/folders", BASE_URL, course_id);
         self.list_items(&url, token).await
+    }
+
+    pub async fn list_folder_folders(&self, folder_id: i32, token: &str) -> Result<Vec<Folder>> {
+        let url = format!("{}/api/v1/folders/{}/folders", BASE_URL, folder_id);
+        self.list_items(&url, token).await
+    }
+
+    pub async fn get_folder_by_id(&self, folder_id: i32, token: &str) -> Result<Folder> {
+        let url = format!("{}/api/v1/folders/{}",BASE_URL, folder_id);
+        let folder = self
+            .get_json_with_token(
+                &url,
+                None::<&str>,
+                token,
+            )
+            .await?;
+        Ok(folder)
     }
 
     pub async fn get_colors(&self, token: &str) -> Result<Colors> {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -204,6 +204,12 @@ impl App {
             .await
     }
 
+    async fn list_folder_folders(&self, folder_id: i32) -> Result<Vec<Folder>> {
+        self.client
+            .list_folder_folders(folder_id, &self.config.read().await.token)
+            .await
+    }
+
     async fn save_file_content(&self, content: &[u8], file_name: &str) -> Result<()> {
         let save_dir = self.config.read().await.save_path.clone();
         let path = Path::new(&save_dir).join(file_name);
@@ -240,6 +246,11 @@ impl App {
         Ok(())
     }
 
+    async fn get_folder_by_id(&self, folder_id: i32) -> Result<Folder> {
+        self.client
+            .get_folder_by_id(folder_id, &self.config.read().await.token)
+            .await
+    }
     async fn get_colors(&self) -> Result<Colors> {
         self.client
             .get_colors(&self.config.read().await.token)
@@ -441,6 +452,9 @@ async fn list_folders(course_id: i32) -> Result<Vec<Folder>> {
 }
 
 #[tauri::command]
+async fn list_folder_folders(folder_id: i32) -> Result<Vec<Folder>> { APP.list_folder_folders(folder_id).await }
+
+#[tauri::command]
 async fn get_config() -> AppConfig {
     APP.get_config().await
 }
@@ -487,6 +501,9 @@ async fn list_calendar_events(
     APP.list_calendar_events(&context_codes, &start_date, &end_date)
         .await
 }
+
+#[tauri::command]
+async fn get_folder_by_id(folder_id: i32) -> Result<Folder> {APP.get_folder_by_id(folder_id).await }
 
 #[tauri::command]
 async fn get_colors() -> Result<Colors> {
@@ -592,7 +609,9 @@ async fn main() -> Result<()> {
             list_course_assignment_submissions,
             list_folder_files,
             list_folders,
+            list_folder_folders,
             list_calendar_events,
+            get_folder_by_id,
             get_colors,
             get_config,
             save_config,

--- a/src/lib/model.ts
+++ b/src/lib/model.ts
@@ -42,6 +42,7 @@ export interface File {
 }
 
 export interface Folder {
+    key: string;
     id: number;
     name: string;
     full_name: string;
@@ -51,6 +52,19 @@ export interface Folder {
     files_url: string;
     files_count: number;
     folders_count: number;
+}
+
+export type Entry = File | Folder;
+export function isFile(entry : Entry) {
+    return 'display_name' in entry;
+}
+export function entryName(entry: Entry) {
+    if(isFile((entry))) {
+        return (entry as File).display_name;
+    }
+    else {
+        return (entry as Folder).name;
+    }
 }
 
 export interface User {

--- a/src/page/assignments.tsx
+++ b/src/page/assignments.tsx
@@ -16,7 +16,7 @@ export default function AssignmentsPage() {
     const [courses, setCourses] = useState<Course[]>([]);
     const [assignments, setAssignments] = useState<Assignment[]>([]);
     const [selectedCourseId, setSelectedCourseId] = useState<number>(-1);
-    const { previewer, onHoverFile, onLeaveFile, setPreviewFile } = usePreview();
+    const { previewer, onHoverEntry, onLeaveEntry, setPreviewEntry } = usePreview();
     const [linksMap, setLinksMap] = useState<Record<number, Attachment[]>>({});
 
     useEffect(() => {
@@ -129,8 +129,8 @@ export default function AssignmentsPage() {
         dataIndex: 'display_name',
         key: 'display_name',
         render: (name: string, attachment: Attachment) => <a
-            onMouseEnter={() => onHoverFile(attachmentToFile(attachment))}
-            onMouseLeave={onLeaveFile}
+            onMouseEnter={() => onHoverEntry(attachmentToFile(attachment))}
+            onMouseLeave={onLeaveEntry}
         >
             {name}
         </a>
@@ -146,7 +146,7 @@ export default function AssignmentsPage() {
                 }}>下载</a>}
                 <a onClick={e => {
                     e.preventDefault();
-                    setPreviewFile(attachmentToFile(attachment));
+                    setPreviewEntry(attachmentToFile(attachment));
                 }}>预览</a>
             </Space>
         ),
@@ -157,8 +157,8 @@ export default function AssignmentsPage() {
         dataIndex: 'display_name',
         key: 'display_name',
         render: (name: string, attachment: Attachment) => <a
-            onMouseEnter={() => onHoverFile(attachmentToFile(attachment))}
-            onMouseLeave={onLeaveFile}
+            onMouseEnter={() => onHoverEntry(attachmentToFile(attachment))}
+            onMouseLeave={onLeaveEntry}
         >
             {name}
         </a>
@@ -184,7 +184,7 @@ export default function AssignmentsPage() {
                 }}>下载</a>}
                 <a onClick={e => {
                     e.preventDefault();
-                    setPreviewFile(attachmentToFile(attachment));
+                    setPreviewEntry(attachmentToFile(attachment));
                 }}>预览</a>
             </Space>
         ),

--- a/src/page/submissions.tsx
+++ b/src/page/submissions.tsx
@@ -26,7 +26,7 @@ export default function SubmissionsPage() {
     const [statistic, setStatistic] = useState<GradeStatistic | undefined>(undefined);
     const [keyword, setKeyword] = useState<string>("");
 
-    const { previewer, onHoverFile, onLeaveFile, setPreviewFile } = usePreview();
+    const { previewer, onHoverEntry, onLeaveEntry, setPreviewEntry } = usePreview();
 
     useEffect(() => {
         initCourses();
@@ -110,8 +110,8 @@ export default function SubmissionsPage() {
         dataIndex: 'display_name',
         key: 'display_name',
         render: (name: string, attachment: Attachment) => <a
-            onMouseEnter={() => onHoverFile(attachmentToFile(attachment))}
-            onMouseLeave={onLeaveFile}
+            onMouseEnter={() => onHoverEntry(attachmentToFile(attachment))}
+            onMouseLeave={onLeaveEntry}
         >
             {name}
         </a>
@@ -137,7 +137,7 @@ export default function SubmissionsPage() {
                 }}>下载</a>}
                 <a onClick={e => {
                     e.preventDefault();
-                    setPreviewFile(attachmentToFile(attachment));
+                    setPreviewEntry(attachmentToFile(attachment));
                 }}>预览</a>
             </Space>
         ),

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,6 +10,13 @@
     "@jridgewell/gen-mapping" "^0.3.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
+"@ant-design/colors@^6.0.0":
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/@ant-design/colors/-/colors-6.0.0.tgz#9b9366257cffcc47db42b9d0203bb592c13c0298"
+  integrity sha512-qAZRvPzfdWHtfameEGP2Qvuf838NhergR35o+EuVyB5XvSA98xod5r4utvi4TJ3ywmevm290g9nsCG5MryrdWQ==
+  dependencies:
+    "@ctrl/tinycolor" "^3.4.0"
+
 "@ant-design/colors@^7.0.0", "@ant-design/colors@^7.0.2":
   version "7.0.2"
   resolved "https://registry.yarnpkg.com/@ant-design/colors/-/colors-7.0.2.tgz#c5c753a467ce8d86ba7ca4736d2c01f599bb5492"
@@ -30,10 +37,22 @@
     rc-util "^5.35.0"
     stylis "^4.0.13"
 
-"@ant-design/icons-svg@^4.4.0":
+"@ant-design/icons-svg@^4.3.0", "@ant-design/icons-svg@^4.4.0":
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/@ant-design/icons-svg/-/icons-svg-4.4.2.tgz#ed2be7fb4d82ac7e1d45a54a5b06d6cecf8be6f6"
   integrity sha512-vHbT+zJEVzllwP+CM+ul7reTEfBR0vgxFe7+lREAsAA7YGsYpboiq2sQNeQeRvh09GfQgs/GyFEvZpJ9cLXpXA==
+
+"@ant-design/icons@^4.8.3":
+  version "4.8.3"
+  resolved "https://registry.yarnpkg.com/@ant-design/icons/-/icons-4.8.3.tgz#41555408ed5e9b0c3d53f3f24fe6a73abfcf4000"
+  integrity sha512-HGlIQZzrEbAhpJR6+IGdzfbPym94Owr6JZkJ2QCCnOkPVIWMO2xgIVcOKnl8YcpijIo39V7l2qQL5fmtw56cMw==
+  dependencies:
+    "@ant-design/colors" "^6.0.0"
+    "@ant-design/icons-svg" "^4.3.0"
+    "@babel/runtime" "^7.11.2"
+    classnames "^2.2.6"
+    lodash "^4.17.15"
+    rc-util "^5.9.4"
 
 "@ant-design/icons@^5.3.0":
   version "5.3.0"
@@ -269,7 +288,7 @@
     "@babel/helper-validator-identifier" "^7.22.20"
     to-fast-properties "^2.0.0"
 
-"@ctrl/tinycolor@^3.6.1":
+"@ctrl/tinycolor@^3.4.0", "@ctrl/tinycolor@^3.6.1":
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/@ctrl/tinycolor/-/tinycolor-3.6.1.tgz#b6c75a56a1947cc916ea058772d666a2c8932f31"
   integrity sha512-SITSV6aIXsuVNV3f3O0f2n/cgyEDWoSqtZMYiAmcsYHydcKrOz3gUxB/iXd/Qf08+IZX4KpgNbvUdMBmWz+kcA==
@@ -1833,6 +1852,11 @@ lie@~3.3.0:
   dependencies:
     immediate "~3.0.5"
 
+lodash@^4.17.15:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+
 longest-streak@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/longest-streak/-/longest-streak-3.1.0.tgz#62fa67cd958742a1574af9f39866364102d90cd4"
@@ -2956,6 +2980,14 @@ rc-util@^5.0.1, rc-util@^5.16.1, rc-util@^5.17.0, rc-util@^5.18.1, rc-util@^5.2.
   version "5.38.2"
   resolved "https://registry.yarnpkg.com/rc-util/-/rc-util-5.38.2.tgz#240da546b51ee838e616f7a2e3fcf62c753b0330"
   integrity sha512-yRGRPKyi84H7NkRSP6FzEIYBdUt4ufdsmXUZ7qM2H5qoByPax70NnGPkfo36N+UKUnUBj2f2Q2eUbwYMuAsIOQ==
+  dependencies:
+    "@babel/runtime" "^7.18.3"
+    react-is "^18.2.0"
+
+rc-util@^5.9.4:
+  version "5.39.1"
+  resolved "https://registry.yarnpkg.com/rc-util/-/rc-util-5.39.1.tgz#7bca4fb55e20add0eef5c23166cd9f9e5f51a8a1"
+  integrity sha512-OW/ERynNDgNr4y0oiFmtes3rbEamXw7GHGbkbNd9iRr7kgT03T6fT0b9WpJ3mbxKhyOcAHnGcIoh5u/cjrC2OQ==
   dependencies:
     "@babel/runtime" "^7.18.3"
     react-is "^18.2.0"


### PR DESCRIPTION
1. 删除选择文件夹的下拉组件，将文件夹与文件都显示在列表中。定义`Entry`为`File | Folder`并修改了一些接口。
2. 点击文件夹以进入。
3. 获取文件和文件夹不再调用api(`/api/v1/courses/:id/files`和`/api/v1/courses/:id/folders`)，因为原有api会返回课程下的所有文件（夹）,破坏了文件树形结构，现在都使用`/api/v1/folders/:id/files`和`/api/v1/folders/:id/folders`。
4.  增加返回上一级目录按钮、根目录按钮、当前路径。
![Screenshot from 2024-03-23 13-10-18](https://github.com/Okabe-Rintarou-0/SJTU-Canvas-Helper/assets/138413915/0e8bba88-4ca0-4e95-a0a9-050355232ced)
