### PR TITLE
workflows: portable for windows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,9 @@ jobs:
             target: x86_64-apple-darwin
           - os: ubuntu-20.04
           - os: windows-latest
+            target: x86_64-pc-windows-msvc
+          - os: windows-latest
+            target: i686-pc-windows-msvc
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -40,6 +43,8 @@ jobs:
         uses: swatinem/rust-cache@v2
         with:
           workspaces: "./src-tauri -> target"
+          key: ${{ matrix.os }}-${{ matrix.target }}
+
       - if: matrix.target
         run: rustup target add ${{ matrix.target }}
 
@@ -65,6 +70,17 @@ jobs:
           releaseDraft: false
           prerelease: false
           args: ${{ matrix.target && format('--target {0}', matrix.target) }}
+
+      - name: Portable Bundle
+        if: matrix.os == 'windows-latest'
+        uses: ./.github/workflows/windows-portable
+        with:
+          target: ${{ matrix.target }}
+          version-template: 'app-v__VERSION__'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAURI_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
+          TAURI_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
 
       - name: update release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/windows-portable/action.yml
+++ b/.github/workflows/windows-portable/action.yml
@@ -1,0 +1,46 @@
+name: 'Windows Portable Action'
+description: 'A composite action for the Windows Portable Bundle workflow'
+inputs:
+  working-directory:
+    description: 'Relative path of the working directory'
+    required: false
+    default: '.'
+  target:
+    description: 'The target to build for'
+    required: false
+    default: 'x86_64-pc-windows-msvc'
+  version-template:
+    description: 'The version template to use'
+    required: false
+    default: 'v__VERSION__'
+runs:
+  using: "composite"
+  steps:
+    - name: Print working directory
+      run: echo "$PWD"
+      shell: bash
+
+    - name: Disable updater
+      run: node ./.github/workflows/windows-portable/disable-updater.mjs
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+
+    - name: Cleanup target
+      run: rm -f ./src-tauri/target/release/*.exe
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+
+    - name: Build
+      run: yarn tauri build --target ${{ inputs.target }}
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+
+    - name: Bundle and upload
+      run: node ./.github/workflows/windows-portable/portable.mjs ${{ inputs.target }} ${{ inputs.version-template }}
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+
+    - name: Restore config
+      run: node ./.github/workflows/windows-portable/restore-config.mjs
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}

--- a/.github/workflows/windows-portable/disable-updater.mjs
+++ b/.github/workflows/windows-portable/disable-updater.mjs
@@ -1,0 +1,20 @@
+import fs from "fs-extra";
+
+async function disableUpdater() {
+    const configPath = "./src-tauri/tauri.conf.json";
+    if (!(await fs.pathExists(configPath))) {
+        throw new Error("could not found the tauri.conf.json");
+    }
+    
+    // backup tauri.conf.json
+    await fs.copyFile(configPath, configPath + ".bak");
+    // load config
+    const config = await fs.readJson(configPath);
+    // modify config
+    config.tauri.updater.dialog = false;
+    config.tauri.bundle.active = false;
+    // save modified config
+    await fs.writeJson(configPath, config);
+}
+
+disableUpdater().catch((err) => { console.error(err); });

--- a/.github/workflows/windows-portable/portable.mjs
+++ b/.github/workflows/windows-portable/portable.mjs
@@ -1,0 +1,83 @@
+import fs from "fs-extra";
+import path from "path";
+import AdmZip from "adm-zip";
+import { getOctokit, context } from "@actions/github";
+
+const target = process.argv.slice(2)[0];
+const tagTemplate = process.argv.slice(2)[1] ?? "v__VERSION__";
+
+const ARCH_MAP = {
+  "x86_64-pc-windows-msvc": "x64",
+  "i686-pc-windows-msvc": "x86",
+  "aarch64-pc-windows-msvc": "arm64",
+};
+
+// 打包绿色版/便携版 (only Windows)
+async function resolvePortable() {
+  if (process.platform !== "win32") return;
+
+  const releaseDir = target
+    ? `./src-tauri/target/${target}/release`
+    : `./src-tauri/target/release`;
+  const configDir = path.join(releaseDir, ".config");
+
+  if (!(await fs.pathExists(releaseDir))) {
+    throw new Error("could not found the release dir");
+  }
+
+  await fs.mkdir(configDir);
+  await fs.createFile(path.join(configDir, "PORTABLE"));
+
+  const configPath = "./src-tauri/tauri.conf.json";
+  const packageJson = await fs.readJson(configPath);
+  const { version, productName } = packageJson["package"];
+
+  const zip = new AdmZip();
+
+  zip.addLocalFile(path.join(releaseDir, `${productName}.exe`));
+  zip.addLocalFolder(configDir, ".config");
+
+  const zipFile = target
+    ? `SJTU.Canvas.Helper_${version}_${ARCH_MAP[target]}_portable.zip`
+    : `SJTU.Canvas.Helper_${version}_portable.zip`;
+  zip.writeZip(zipFile);
+
+  console.log("[INFO]: create portable zip successfully");
+
+  // push release assets
+  if (process.env.GITHUB_TOKEN === undefined) {
+    throw new Error("GITHUB_TOKEN is required");
+  }
+
+  const options = { owner: context.repo.owner, repo: context.repo.repo };
+  const github = getOctokit(process.env.GITHUB_TOKEN);
+  const tag = process.env.TAG_NAME || tagTemplate.replace("__VERSION__", version);
+  console.log("[INFO]: upload to ", tag);
+
+  const { data: release } = await github.rest.repos.getReleaseByTag({
+    ...options,
+    tag,
+  });
+
+  let assets = release.assets.filter((x) => {
+    return x.name === zipFile;
+  });
+  if (assets.length > 0) {
+    let id = assets[0].id;
+    await github.rest.repos.deleteReleaseAsset({
+      ...options,
+      asset_id: id,
+    });
+  }
+
+  console.log(release.name);
+
+  await github.rest.repos.uploadReleaseAsset({
+    ...options,
+    release_id: release.id,
+    name: zipFile,
+    data: zip.toBuffer(),
+  });
+}
+
+resolvePortable().catch(console.error);

--- a/.github/workflows/windows-portable/restore-config.mjs
+++ b/.github/workflows/windows-portable/restore-config.mjs
@@ -1,0 +1,13 @@
+import fs from "fs-extra";
+
+async function restoreConfig() {
+    const configPath = "./src-tauri/tauri.conf.json";
+    if (!(await fs.pathExists(configPath + ".bak"))) {
+        throw new Error("could not found the tauri.conf.json.bak");
+    }
+
+    await fs.remove(configPath);
+    await fs.copyFile(configPath + ".bak", configPath);
+}
+
+restoreConfig().catch((err) => { console.error(err); });

--- a/package.json
+++ b/package.json
@@ -37,6 +37,9 @@
     "xlsx": "^0.18.5"
   },
   "devDependencies": {
+    "@actions/github": "^5.1.1",
+    "fs-extra": "^11.2.0",
+    "adm-zip": "^0.5.10",
     "@tauri-apps/cli": "^1.5.10",
     "@types/react": "^18.2.15",
     "@types/react-dom": "^18.2.7",


### PR DESCRIPTION
1. 为windows发布添加了便携版
2. 增加了windows x86 的发布版本
3. 为不同的架构单独设置rust缓存，减少重编译
4. 为yarn依赖增加缓存