### PR TITLE
fix: 2 bugs in submitting assignment

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 tauri-build = { version = "1", features = [] }
 
 [dependencies]
-tauri = { version = "1", features = [
+tauri = { version = "1", features = [ "path-all",
     "dialog-all",
     "updater",
     "process-relaunch",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -25,6 +25,9 @@
         "confirm": true,
         "message": true,
         "open": true
+      },
+      "path": {
+        "all": true
       }
     },
     "windows": [


### PR DESCRIPTION
1. An assignment has an `allowed_extensions` member with default value [] (empty string list), which does not allow users to select files.

2. After selecting some files, the frontend will display it's absolute file path instead of its **file base name**. This was described in this post: https://shuiyuan.sjtu.edu.cn/t/topic/245275/333.