### PR TITLE
fix: Legacy Class Video External Tool URL Changed again

### DIFF
--- a/src-tauri/src/client/video.rs
+++ b/src-tauri/src/client/video.rs
@@ -154,7 +154,7 @@ impl Client {
         course_id: i64,
     ) -> Result<Option<HashMap<String, String>>> {
         let url = format!(
-            "https://oc.sjtu.edu.cn/courses/{}/external_tools/8199",
+            "https://oc.sjtu.edu.cn/courses/{}/external_tools/8332",
             course_id
         );
         let response = self.cli.get(&url).send().await?;


### PR DESCRIPTION
```
<a href="/courses/52101/external_tools/8332" class="context_external_tool_8332" tabindex="0">课堂视频</a>
```