### PR TITLE
fix: get canvas_course_id from API

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5366,6 +5366,7 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
+ "urlencoding",
  "uuid",
  "warp",
 ]
@@ -6761,6 +6762,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "urlpattern"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -47,6 +47,7 @@ tauri-plugin-dialog = "2"
 dirs = "5.0.1"
 tokio-util = { version = "0.7", features = ["io"] }
 rust_xlsxwriter = "0.90.2"
+urlencoding = "2.1.3"
 [dependencies.uuid]
 version = "1.8.0"
 features = [


### PR DESCRIPTION
Resolves #77 by fetching `canvas_course_id` from [https://v.sjtu.edu.cn/jy-application-canvas-sjtu/lti3/getAccessTokenByTokenId?tokenId=](https://v.sjtu.edu.cn/jy-application-canvas-sjtu/lti3/getAccessTokenByTokenId?tokenId=), as the redirected URL no longer contains the parameter `courId`.